### PR TITLE
Add X-CSRFToken header

### DIFF
--- a/graphene_graphiql_explorer/src/src/App.js
+++ b/graphene_graphiql_explorer/src/src/App.js
@@ -9,6 +9,8 @@ import { makeDefaultArg, getDefaultScalarArgValue } from "./CustomArgs";
 import "graphiql/graphiql.css";
 import "./App.css";
 
+const csrftoken = document.querySelector('[name=csrfmiddlewaretoken]').value;
+
 function fetcher(params, opts) {
   if (typeof opts === "undefined") {
     opts = {};
@@ -16,6 +18,7 @@ function fetcher(params, opts) {
   var headers = opts.headers || {};
   headers["Accept"] = headers["Accept"] || "application/json";
   headers["Content-Type"] = headers["Content-Type"] || "application/json";
+  headers["X-CSRFToken"] = headers["X-CSRFToken"] || csrftoken;
   const url = `//${window.location.host}${window.location.pathname}`;
   return fetch(url, {
     method: "POST",


### PR DESCRIPTION
As per https://docs.djangoproject.com/en/4.1/howto/csrf/#setting-the-token-on-the-ajax-request all POST requests must contain the X-CSRFToken header or use the hidden form field. The hidden form field is already part of the template, the missing bits are sending it as a header in the request. This PR adds that missing bit.